### PR TITLE
Fix log formatting in sensors module

### DIFF
--- a/sensors/sensors.py
+++ b/sensors/sensors.py
@@ -423,7 +423,7 @@ try:
             GPIO.output(ledGreen, GPIO.HIGH)
             GPIO.output(ledRed, GPIO.LOW)
         except Exception as e:
-            print("System error: {e}")
+            print(f"System error: {e}")
             GPIO.output(ledGreen, GPIO.LOW)
             GPIO.output(ledRed, GPIO.HIGH)
             


### PR DESCRIPTION
## Summary
- correct f-string for exception logging in `sensors.py`

## Testing
- `python3 -m py_compile sensors/sensors.py`


------
https://chatgpt.com/codex/tasks/task_e_684d17794cc8832898d8fd7a17bebcc5